### PR TITLE
Add joystick connected / disconnected events

### DIFF
--- a/src/emu/emulator.c
+++ b/src/emu/emulator.c
@@ -149,7 +149,7 @@ static void emu_joy_add(void *data, int joystick_index) {
 static void emu_joy_remove(void *data, int joystick_index) {
   struct emu *emu = data;
 
-  dc_joy_add(emu->dc, joystick_index);
+  dc_joy_remove(emu->dc, joystick_index);
 }
 
 static void emu_close(void *data) {

--- a/src/emu/emulator.c
+++ b/src/emu/emulator.c
@@ -235,11 +235,16 @@ struct emu *emu_create(struct window *window) {
   struct emu *emu = calloc(1, sizeof(struct emu));
 
   emu->window = window;
-  emu->listener =
-      (struct window_listener){emu,                  &emu_paint,            &emu_debug_menu,
-                               &emu_joy_add,         &emu_joy_remove,       &emu_keydown,
-                               NULL,                 NULL,                  &emu_close,
-                               {0}};
+  emu->listener = (struct window_listener){emu,
+                                           &emu_paint,
+                                           &emu_debug_menu,
+                                           &emu_joy_add,
+                                           &emu_joy_remove,
+                                           &emu_keydown,
+                                           NULL,
+                                           NULL,
+                                           &emu_close,
+                                           {0}};
   win_add_listener(emu->window, &emu->listener);
 
   return emu;

--- a/src/emu/emulator.c
+++ b/src/emu/emulator.c
@@ -140,6 +140,18 @@ static void emu_keydown(void *data, int device_index, enum keycode code,
   dc_keydown(emu->dc, device_index, code, value);
 }
 
+static void emu_joy_add(void *data, int joystick_index) {
+  struct emu *emu = data;
+
+  dc_joy_add(emu->dc, joystick_index);
+}
+
+static void emu_joy_remove(void *data, int joystick_index) {
+  struct emu *emu = data;
+
+  dc_joy_add(emu->dc, joystick_index);
+}
+
 static void emu_close(void *data) {
   struct emu *emu = data;
 
@@ -224,8 +236,10 @@ struct emu *emu_create(struct window *window) {
 
   emu->window = window;
   emu->listener =
-      (struct window_listener){emu,  &emu_paint, &emu_debug_menu, &emu_keydown,
-                               NULL, NULL,       &emu_close,      {0}};
+      (struct window_listener){emu,                  &emu_paint,            &emu_debug_menu,
+                               &emu_joy_add,         &emu_joy_remove,       &emu_keydown,
+                               NULL,                 NULL,                  &emu_close,
+                               {0}};
   win_add_listener(emu->window, &emu->listener);
 
   return emu;

--- a/src/emu/tracer.c
+++ b/src/emu/tracer.c
@@ -864,8 +864,8 @@ struct tracer *tracer_create(struct window *window) {
 
   tracer->window = window;
   tracer->listener = (struct window_listener){
-      tracer, &tracer_paint, NULL,          &tracer_keydown,
-      NULL,   NULL,          &tracer_close, {0}};
+      tracer,          &tracer_paint, NULL,          NULL,          NULL,
+      &tracer_keydown, NULL,          NULL,          &tracer_close, {0}};
   tracer->provider =
       (struct texture_provider){tracer, &tracer_texture_provider_find_texture};
   tracer->rb = window->rb;

--- a/src/hw/dreamcast.c
+++ b/src/hw/dreamcast.c
@@ -94,6 +94,19 @@ void dc_keydown(struct dreamcast *dc, int device_index, enum keycode code,
   }
 }
 
+void dc_joy_add(struct dreamcast *dc, int joystick_index) {
+  list_for_each_entry(dev, &dc->devices, struct device, it) {
+    if(dev->window_if && dev->window_if->joy_add)
+      dev->window_if->joy_add(dev, joystick_index);
+  }
+}
+void dc_joy_remove(struct dreamcast *dc, int joystick_index) {
+  list_for_each_entry(dev, &dc->devices, struct device, it) {
+    if(dev->window_if && dev->window_if->joy_remove)
+      dev->window_if->joy_remove(dev, joystick_index);
+  }
+}
+
 struct execute_interface *dc_create_execute_interface(device_run_cb run,
                                                       int running) {
   struct execute_interface *execute =

--- a/src/hw/dreamcast.c
+++ b/src/hw/dreamcast.c
@@ -134,10 +134,13 @@ void dc_destroy_memory_interface(struct memory_interface *memory) {
 }
 
 struct window_interface *dc_create_window_interface(
-    device_debug_menu_cb debug_menu, device_keydown_cb keydown) {
+    device_debug_menu_cb debug_menu, device_keydown_cb keydown,
+    device_joy_add_cb joy_add,       device_joy_remove_cb joy_remove) {
   struct window_interface *window = calloc(1, sizeof(struct window_interface));
   window->debug_menu = debug_menu;
   window->keydown = keydown;
+  window->joy_add = joy_add;
+  window->joy_remove = joy_remove;
   return window;
 }
 

--- a/src/hw/dreamcast.h
+++ b/src/hw/dreamcast.h
@@ -169,7 +169,8 @@ struct memory_interface *dc_create_memory_interface(struct dreamcast *dc,
 void dc_destroy_memory_interface(struct memory_interface *memory);
 
 struct window_interface *dc_create_window_interface(
-    device_debug_menu_cb debug_menu, device_keydown_cb keydown);
+    device_debug_menu_cb debug_menu, device_keydown_cb keydown,
+    device_joy_add_cb joy_add,       device_joy_remove_cb joy_remove);
 void dc_destroy_window_interface(struct window_interface *window);
 
 void *dc_create_device(struct dreamcast *dc, size_t size, const char *name,

--- a/src/hw/dreamcast.h
+++ b/src/hw/dreamcast.h
@@ -87,10 +87,14 @@ struct memory_interface {
 // window interface
 typedef void (*device_debug_menu_cb)(struct device *, struct nk_context *);
 typedef void (*device_keydown_cb)(struct device *, int, enum keycode, int16_t);
+typedef void (*device_joy_add_cb)(struct device *, int);
+typedef void (*device_joy_remove_cb)(struct device *, int);
 
 struct window_interface {
   device_debug_menu_cb debug_menu;
   device_keydown_cb keydown;
+  device_joy_add_cb joy_add;
+  device_joy_remove_cb  joy_remove;
 };
 
 //
@@ -153,6 +157,8 @@ void dc_tick(struct dreamcast *dc, int64_t ns);
 void dc_debug_menu(struct dreamcast *dc, struct nk_context *ctx);
 void dc_keydown(struct dreamcast *dc, int device_index, enum keycode code,
                 int16_t value);
+void dc_joy_add(struct dreamcast *dc, int joystick_index);
+void dc_joy_remove(struct dreamcast *dc, int joystick_index);
 
 struct execute_interface *dc_create_execute_interface(device_run_cb run,
                                                       int running);

--- a/src/hw/maple/maple.c
+++ b/src/hw/maple/maple.c
@@ -32,13 +32,10 @@ void maple_joy_add(struct device *d, int joystick_index) {
   }
   struct maple *mp = (struct maple *)d;
 
-  /* Attach joystick to the first available port */
-  for (int i = 0; i <= joystick_index; i++) {
-    if (!mp->devices[i][0]) {
-      maple_register_device(mp, "controller", i, 0);
-      break;
-    }
-  }
+  /* Attach joystick to the corresponding maple port */
+  if(!mp->devices[joystick_index][0])
+    maple_register_device(mp, "controller", joystick_index, 0);
+
 }
 
 void maple_joy_remove(struct device *d, int joystick_index) {

--- a/src/hw/maple/maple.c
+++ b/src/hw/maple/maple.c
@@ -26,6 +26,11 @@ static void maple_register_device(struct maple *mp, const char *device_type,
   }
 }
 
+void maple_joy_add(struct device *d, int joystick_index) {
+  LOG_INFO("NEW SUPER COOL JOYSTICK ADDED LMAO");
+
+}
+
 static void maple_keydown(struct device *d, int device_index, enum keycode key,
                           int16_t value) {
   if (device_index >= MAPLE_NUM_PORTS) {
@@ -144,6 +149,7 @@ struct maple *maple_create(struct dreamcast *dc) {
       dc_create_device(dc, sizeof(struct maple), "maple", &maple_init);
   mp->window_if = dc_create_window_interface(NULL, &maple_keydown);
 
+  mp->window_if->joy_add = &maple_joy_add;
   /* add one controller and vmu by default */
   maple_register_device(mp, "controller", 0, 0);
   maple_register_device(mp, "vmu", 0, 1);

--- a/src/hw/maple/maple.c
+++ b/src/hw/maple/maple.c
@@ -27,8 +27,37 @@ static void maple_register_device(struct maple *mp, const char *device_type,
 }
 
 void maple_joy_add(struct device *d, int joystick_index) {
-  LOG_INFO("NEW SUPER COOL JOYSTICK ADDED LMAO");
+  if(joystick_index >= MAPLE_NUM_PORTS) {
+    return;
+  }
+  struct maple *mp = (struct maple *)d;
 
+  /* Attach joystick to the first available port */
+  for(int i = 0; i <= joystick_index; i++) {
+    if (!mp->devices[i][0]) {
+      maple_register_device(mp, "controller", i, 0);
+      break;
+    }
+  }
+
+
+}
+
+void maple_joy_remove(struct device *d, int joystick_index) {
+  if(joystick_index >= MAPLE_NUM_PORTS) {
+    return;
+  }
+  struct maple *mp = (struct maple *)d;
+
+  /* Remove all units for this joystick */
+  for(int i = 0; i < MAPLE_MAX_UNITS; i++) {
+    struct maple_device *dev = mp->devices[joystick_index][i];
+
+    if(dev && dev->destroy) {
+      dev->destroy(dev);
+      mp->devices[joystick_index][i] = NULL;
+    }
+  }
 }
 
 static void maple_keydown(struct device *d, int device_index, enum keycode key,
@@ -38,11 +67,6 @@ static void maple_keydown(struct device *d, int device_index, enum keycode key,
   }
 
   struct maple *mp = (struct maple *)d;
-
-  /* create a controller if getting data from a new device */
-  if (!mp->devices[device_index][0]) {
-    maple_register_device(mp, "controller", device_index, 0);
-  }
 
   for (int i = 0; i < MAPLE_MAX_UNITS; i++) {
     struct maple_device *dev = mp->devices[device_index][i];
@@ -147,9 +171,9 @@ void maple_destroy(struct maple *mp) {
 struct maple *maple_create(struct dreamcast *dc) {
   struct maple *mp =
       dc_create_device(dc, sizeof(struct maple), "maple", &maple_init);
-  mp->window_if = dc_create_window_interface(NULL, &maple_keydown);
+  mp->window_if = dc_create_window_interface(NULL, &maple_keydown, &maple_joy_add,
+                                             &maple_joy_remove);
 
-  mp->window_if->joy_add = &maple_joy_add;
   /* add one controller and vmu by default */
   maple_register_device(mp, "controller", 0, 0);
   maple_register_device(mp, "vmu", 0, 1);

--- a/src/hw/maple/maple.c
+++ b/src/hw/maple/maple.c
@@ -27,33 +27,31 @@ static void maple_register_device(struct maple *mp, const char *device_type,
 }
 
 void maple_joy_add(struct device *d, int joystick_index) {
-  if(joystick_index >= MAPLE_NUM_PORTS) {
+  if (joystick_index >= MAPLE_NUM_PORTS) {
     return;
   }
   struct maple *mp = (struct maple *)d;
 
   /* Attach joystick to the first available port */
-  for(int i = 0; i <= joystick_index; i++) {
+  for (int i = 0; i <= joystick_index; i++) {
     if (!mp->devices[i][0]) {
       maple_register_device(mp, "controller", i, 0);
       break;
     }
   }
-
-
 }
 
 void maple_joy_remove(struct device *d, int joystick_index) {
-  if(joystick_index >= MAPLE_NUM_PORTS) {
+  if (joystick_index >= MAPLE_NUM_PORTS) {
     return;
   }
   struct maple *mp = (struct maple *)d;
 
   /* Remove all units for this joystick */
-  for(int i = 0; i < MAPLE_MAX_UNITS; i++) {
+  for (int i = 0; i < MAPLE_MAX_UNITS; i++) {
     struct maple_device *dev = mp->devices[joystick_index][i];
 
-    if(dev && dev->destroy) {
+    if (dev && dev->destroy) {
       dev->destroy(dev);
       mp->devices[joystick_index][i] = NULL;
     }
@@ -171,8 +169,8 @@ void maple_destroy(struct maple *mp) {
 struct maple *maple_create(struct dreamcast *dc) {
   struct maple *mp =
       dc_create_device(dc, sizeof(struct maple), "maple", &maple_init);
-  mp->window_if = dc_create_window_interface(NULL, &maple_keydown, &maple_joy_add,
-                                             &maple_joy_remove);
+  mp->window_if = dc_create_window_interface(NULL, &maple_keydown,
+                                             &maple_joy_add, &maple_joy_remove);
 
   /* add one controller and vmu by default */
   maple_register_device(mp, "controller", 0, 0);

--- a/src/hw/pvr/ta.c
+++ b/src/hw/pvr/ta.c
@@ -950,7 +950,7 @@ struct ta *ta_create(struct dreamcast *dc) {
   ta_build_tables();
 
   struct ta *ta = dc_create_device(dc, sizeof(struct ta), "ta", &ta_init);
-  ta->window_if = dc_create_window_interface(&ta_debug_menu, NULL);
+  ta->window_if = dc_create_window_interface(&ta_debug_menu, NULL, NULL, NULL);
   ta->provider =
       (struct texture_provider){ta, &ta_texture_provider_find_texture};
   ta->pending_mutex = mutex_create();

--- a/src/hw/sh4/sh4.c
+++ b/src/hw/sh4/sh4.c
@@ -338,7 +338,8 @@ struct sh4 *sh4_create(struct dreamcast *dc) {
   struct sh4 *sh4 = dc_create_device(dc, sizeof(struct sh4), "sh", &sh4_init);
   sh4->execute_if = dc_create_execute_interface(&sh4_run, 0);
   sh4->memory_if = dc_create_memory_interface(dc, &sh4_data_map);
-  sh4->window_if = dc_create_window_interface(&sh4_debug_menu, NULL, NULL, NULL);
+  sh4->window_if =
+      dc_create_window_interface(&sh4_debug_menu, NULL, NULL, NULL);
 
   return sh4;
 }

--- a/src/hw/sh4/sh4.c
+++ b/src/hw/sh4/sh4.c
@@ -338,7 +338,7 @@ struct sh4 *sh4_create(struct dreamcast *dc) {
   struct sh4 *sh4 = dc_create_device(dc, sizeof(struct sh4), "sh", &sh4_init);
   sh4->execute_if = dc_create_execute_interface(&sh4_run, 0);
   sh4->memory_if = dc_create_memory_interface(dc, &sh4_data_map);
-  sh4->window_if = dc_create_window_interface(&sh4_debug_menu, NULL);
+  sh4->window_if = dc_create_window_interface(&sh4_debug_menu, NULL, NULL, NULL);
 
   return sh4;
 }

--- a/src/ui/microprofile.cc
+++ b/src/ui/microprofile.cc
@@ -271,7 +271,7 @@ struct microprofile *mp_create(struct window *window) {
       calloc(1, sizeof(struct microprofile)));
 
   mp->window = window;
-  mp->listener = {mp, NULL, NULL, &mp_keydown, NULL, &mp_mousemove, NULL, {}};
+  mp->listener = {mp, NULL, NULL, NULL, NULL, &mp_keydown, NULL, &mp_mousemove, NULL, {}};
 
   win_add_listener(mp->window, &mp->listener);
 

--- a/src/ui/nuklear.c
+++ b/src/ui/nuklear.c
@@ -160,7 +160,8 @@ struct nuklear *nk_create(struct window *window) {
   struct nuklear *nk = calloc(1, sizeof(struct nuklear));
   nk->window = window;
   nk->listener = (struct window_listener){
-      nk, NULL, NULL, &nk_keydown, &nk_textinput, &nk_mousemove, NULL, {0}};
+      nk,          NULL,          NULL,          NULL, NULL,
+      &nk_keydown, &nk_textinput, &nk_mousemove, NULL, {0}};
 
   win_add_listener(nk->window, &nk->listener);
 

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -40,7 +40,10 @@ static void win_create_joystick(struct window *win, int joystick_index) {
 
     /* reset state */
     memset(win->hat_state[i], 0, sizeof(win->hat_state[i]));
-
+    list_for_each_entry(listener, &win->listeners, struct window_listener, it) {
+      if(listener->joy_add)
+        listener->joy_add(listener->data, joystick_index);
+    }
     break;
   }
 }

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -18,6 +18,10 @@ static void win_destroy_joystick(struct window *win, SDL_Joystick *del) {
     if (*joy == del) {
       SDL_JoystickClose(*joy);
       *joy = NULL;
+      list_for_each_entry(listener, &win->listeners, struct window_listener, it) {
+        if(listener->joy_remove)
+          listener->joy_remove(listener->data, i);
+      }
     }
   }
 }

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -18,8 +18,9 @@ static void win_destroy_joystick(struct window *win, SDL_Joystick *del) {
     if (*joy == del) {
       SDL_JoystickClose(*joy);
       *joy = NULL;
-      list_for_each_entry(listener, &win->listeners, struct window_listener, it) {
-        if(listener->joy_remove)
+      list_for_each_entry(listener, &win->listeners, struct window_listener,
+                          it) {
+        if (listener->joy_remove)
           listener->joy_remove(listener->data, i);
       }
     }
@@ -45,7 +46,7 @@ static void win_create_joystick(struct window *win, int joystick_index) {
     /* reset state */
     memset(win->hat_state[i], 0, sizeof(win->hat_state[i]));
     list_for_each_entry(listener, &win->listeners, struct window_listener, it) {
-      if(listener->joy_add)
+      if (listener->joy_add)
         listener->joy_add(listener->data, joystick_index);
     }
     break;

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -32,6 +32,8 @@ struct window_listener {
   void *data;
   void (*paint)(void *data);
   void (*debug_menu)(void *data, struct nk_context *ctx);
+  void (*joy_add)(void *data, int joystick_index);
+  void (*joy_remove)(void *data, int joystick_index);
   void (*keydown)(void *data, int device_index, enum keycode code,
                   int16_t value);
   void (*textinput)(void *data, const char *text);

--- a/src/video/gl_backend.c
+++ b/src/video/gl_backend.c
@@ -722,7 +722,7 @@ struct render_backend *rb_create(struct window *window) {
   struct render_backend *rb = calloc(1, sizeof(struct render_backend));
   rb->window = window;
   rb->listener = (struct window_listener){
-      rb, NULL, &rb_debug_menu, NULL, NULL, NULL, NULL, {0}};
+      rb, NULL, &rb_debug_menu, NULL, NULL, NULL, NULL, NULL, NULL, {0}};
 
   win_add_listener(rb->window, &rb->listener);
 


### PR DESCRIPTION
Fixes Issue #33. It currently assigns a joystick to the first available maple port. VMU creation isn't handled by this PR, so new joysticks won't have any sub-devices created. Once #31 is resolved it might be good to just automatically create a VMU when adding a joystick