### PR TITLE
Fix SDL2 dependency on newer wayland API

### DIFF
--- a/deps/sdl2-2.0.4/src/video/wayland/SDL_waylanddyn.h
+++ b/deps/sdl2-2.0.4/src/video/wayland/SDL_waylanddyn.h
@@ -79,6 +79,7 @@ void SDL_WAYLAND_UnloadSymbols(void);
 #define wl_proxy_get_user_data (*WAYLAND_wl_proxy_get_user_data)
 #define wl_proxy_add_listener (*WAYLAND_wl_proxy_add_listener)
 #define wl_proxy_marshal_constructor (*WAYLAND_wl_proxy_marshal_constructor)
+#define wl_proxy_marshal_constructor_versioned (*WAYLAND_wl_proxy_marshal_constructor_versioned)
 
 #define wl_seat_interface (*WAYLAND_wl_seat_interface)
 #define wl_surface_interface (*WAYLAND_wl_surface_interface)

--- a/deps/sdl2-2.0.4/src/video/wayland/SDL_waylandsym.h
+++ b/deps/sdl2-2.0.4/src/video/wayland/SDL_waylandsym.h
@@ -55,6 +55,9 @@ SDL_WAYLAND_SYM(void, wl_list_insert_list, (struct wl_list *, struct wl_list *))
 SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_4)
 SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor, (struct wl_proxy *, uint32_t opcode, const struct wl_interface *interface, ...))
 
+SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_10)
+SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor_versioned, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version, ...))
+
 SDL_WAYLAND_INTERFACE(wl_seat_interface)
 SDL_WAYLAND_INTERFACE(wl_surface_interface)
 SDL_WAYLAND_INTERFACE(wl_shm_pool_interface)


### PR DESCRIPTION
This PR backports the Wayland 1.10+ patch so the included version of SDL will build properly in this environment.

The relevant patch added is here: https://hg.libsdl.org/SDL/rev/330f500d5815

Closes #42