### PR TITLE
Add audio latency option

### DIFF
--- a/docs/_docs/running.md
+++ b/docs/_docs/running.md
@@ -13,6 +13,7 @@ Command line flags are loaded from and saved to `$HOME/.redream/flags` each run.
 ```
        --bios  Path to BIOS                                            [default: dc_boot.bin]
       --flash  Path to flash ROM                                       [default: dc_flash.bin]
+    --latency  Set preferred audio latency in MS                       [default: 100]
  --controller  Path to controller profile
    --throttle  Throttle emulation speed to match the original hardware [default: 1]
     --verbose  Enable debug logging                                    [default: 0]

--- a/src/audio/soundio_backend.c
+++ b/src/audio/soundio_backend.c
@@ -2,6 +2,8 @@
 #include "audio/audio_backend.h"
 #include "hw/aica/aica.h"
 
+DEFINE_OPTION_INT(latency, 100, "Set preferred audio latency in MS");
+
 struct audio_backend {
   struct aica *aica;
   struct SoundIo *soundio;
@@ -141,6 +143,7 @@ struct audio_backend *audio_create(struct aica *aica) {
     audio->outstream->userdata = audio;
     audio->outstream->write_callback = &audio_write_callback;
     audio->outstream->underflow_callback = &audio_underflow_callback;
+    audio->outstream->software_latency = OPTION_latency / 1000.0;
 
     if ((err = soundio_outstream_open(audio->outstream))) {
       LOG_WARNING("Error opening audio device: %s", soundio_strerror(err));


### PR DESCRIPTION
Allows the user to specify the desired audio latency from the command line
Defaults to 100ms