### PR TITLE
Fix host audio underflow by emitting silence when necessary

### DIFF
--- a/src/audio/audio_backend.h
+++ b/src/audio/audio_backend.h
@@ -7,6 +7,7 @@ struct audio_backend;
 struct audio_backend *audio_create(struct aica *aica);
 void audio_destroy(struct audio_backend *audio);
 
+int audio_buffer_low(struct audio_backend *audio);
 void audio_pump_events(struct audio_backend *audio);
 
 #endif

--- a/src/emu/emulator.c
+++ b/src/emu/emulator.c
@@ -214,13 +214,13 @@ static void *emu_core_thread(void *data) {
   int64_t next_pump_time = 0;
 
   while (emu->running) {
-    current_time = time_nanoseconds();
-
     while (audio_buffer_low(audio)) {
       dc_tick(emu->dc, MACHINE_STEP);
     }
 
     /* audio events are just for device connections, check infrequently */
+    current_time = time_nanoseconds();
+
     if (current_time > next_pump_time) {
       audio_pump_events(audio);
       next_pump_time = current_time + NS_PER_SEC;

--- a/src/emu/emulator.c
+++ b/src/emu/emulator.c
@@ -17,8 +17,6 @@
 #include "ui/nuklear.h"
 #include "ui/window.h"
 
-DEFINE_OPTION_INT(throttle, 1,
-                  "Throttle emulation speed to match the original hardware");
 DEFINE_AGGREGATE_COUNTER(frames);
 
 struct emu {
@@ -110,15 +108,6 @@ static void emu_debug_menu(void *data, struct nk_context *ctx) {
            frames, ta_renders, pvr_vblanks, sh4_instrs, arm7_instrs);
   win_set_status(emu->window, status);
 
-  /* add drop down menus */
-  nk_layout_row_push(ctx, 70.0f);
-  if (nk_menu_begin_label(ctx, "EMULATOR", NK_TEXT_LEFT,
-                          nk_vec2(140.0f, 200.0f))) {
-    nk_layout_row_dynamic(ctx, DEBUG_MENU_HEIGHT, 1);
-    nk_checkbox_label(ctx, "throttled", &OPTION_throttle);
-    nk_menu_end(ctx);
-  }
-
   dc_debug_menu(emu->dc, ctx);
 }
 
@@ -154,9 +143,8 @@ static void emu_close(void *data) {
   emu->running = 0;
 }
 
-static void *emu_audio_thread(void *data) {
+static void *emu_core_thread(void *data) {
   struct emu *emu = data;
-
   struct audio_backend *audio = audio_create(emu->dc->aica);
 
   if (!audio) {
@@ -164,43 +152,84 @@ static void *emu_audio_thread(void *data) {
     return 0;
   }
 
-  while (emu->running) {
-    audio_pump_events(audio);
+  /* main emulation loop
 
-    /* audio_pump_events just checks for device changes, there's no need to
-       spin */
-    sleep(1);
-  }
+     unlike the real machine which runs multiple hardware devices in parallel,
+     all of the emulated hardware in redream is ran synchronously, in a
+     cooperative multitasking fashion. this removes numerous complexities in
+     the c code, as well as the runtime generated code.
 
-  audio_destroy(audio);
+     on creation, each hardware device registers itself with the scheduler
+     interface. this scheduler interface is used by dc_tick to run each device
+     for the specified slice of guest time. baring in mind that each device is
+     ran synchronously, this slice should be low enough that devices waiting on
+     interrupts from eachother are serviced regularly, but high enough that
+     there's not too much context switching. please note, it's extremely
+     important that this slice is constant to keep emulation deterministic
+     between runs.
 
-  return 0;
-}
+     the next issue tackled by this loop is, when should dc_tick be called to
+     execute this constant slice of time. the answer really depends on what
+     the goal of emulation is.
 
-static void *emu_core_thread(void *data) {
-  struct emu *emu = data;
+     when the goal is to run completely unthrottled, it should be called as much
+     as possible, e.g.:
+
+       while (1) {
+         dc_tick(slice);
+       }
+
+     when the goal is to run at the same speed as the original dreamcast, the
+     answer is a bit more involved. at first it may seem desirable to use the
+     host machine's clock to schedule each slice, e.g.:
+
+       while (1) {
+         current_time = time();
+         delta_time = next_time - current_time;
+
+         if (delta_time < 0) {
+           dc_tick(slice);
+           next_time = current_time + delta_time + slice;
+         }
+       }
+
+     this will, in general, run the emulator at the same rate as the original
+     dreamcast. when performance hiccups, the host's time domain will move
+     forward, while the emulator's time domain will fall behind. the emulator
+     will then speed up temporarily due to the delta_time offset, eventually
+     synchronizing it's view of time with the host as delta_time approaches 0.
+
+     the downsides to this approach are audio, and video to some degree, are
+     not presented well when performance hiccups. imagine the scenario that
+     performance grinds to a complete halt for 5 seconds. in this case, host
+     time is 5 seconds ahead of guest time, the loop will run 5 seconds worth
+     of emulator time in say, 1 second of host time, again synchronizing the
+     time domains. the problem being that, now 5 seconds of audio and video
+     have been generated for something the user has experienced for only 1
+     second. skipping video frames in this case isn't the worst experience
+     but crackling and distorted audio can be awful. */
 
   static const int64_t MACHINE_STEP = HZ_TO_NANO(1000);
-  int64_t current_time = time_nanoseconds();
-  int64_t next_time = current_time;
-  int64_t delta_time = 0;
+  int64_t current_time = 0;
+  int64_t next_pump_time = 0;
 
   while (emu->running) {
     current_time = time_nanoseconds();
 
-    if (OPTION_throttle) {
-      delta_time = current_time - next_time;
-    } else {
-      delta_time = 0;
+    while (audio_buffer_low(audio)) {
+      dc_tick(emu->dc, MACHINE_STEP);
     }
 
-    if (delta_time >= 0) {
-      dc_tick(emu->dc, MACHINE_STEP);
-      next_time = current_time + MACHINE_STEP - delta_time;
+    /* audio events are just for device connections, check infrequently */
+    if (current_time > next_pump_time) {
+      audio_pump_events(audio);
+      next_pump_time = current_time + NS_PER_SEC;
     }
 
     prof_update(current_time);
   }
+
+  audio_destroy(audio);
 
   return 0;
 }
@@ -244,7 +273,6 @@ void emu_run(struct emu *emu, const char *path) {
      produces complete frames of decoded data, and the audio and video
      thread are responsible for simply presenting the data */
   thread_t core_thread = thread_create(&emu_core_thread, NULL, emu);
-  thread_t audio_thread = thread_create(&emu_audio_thread, NULL, emu);
 
   while (emu->running) {
     win_pump_events(emu->window);
@@ -252,7 +280,6 @@ void emu_run(struct emu *emu, const char *path) {
 
   /* wait for the core thread to exit */
   void *result;
-  thread_join(audio_thread, &result);
   thread_join(core_thread, &result);
 }
 

--- a/src/hw/aica/aica.c
+++ b/src/hw/aica/aica.c
@@ -22,7 +22,6 @@ DEFINE_AGGREGATE_COUNTER(aica_samples);
 #define LOG_AICA(...)
 #endif
 
-#define AICA_SAMPLE_FREQ 44100
 #define AICA_SAMPLE_BATCH 10
 #define AICA_NUM_CHANNELS 64
 
@@ -389,16 +388,6 @@ static void aica_write_frames(struct aica *aica, const void *frames,
   if (aica->recording) {
     fwrite(frames, 1, size, aica->recording);
   }
-}
-
-int aica_skip_frames(struct aica *aica, int num_frames) {
-  int available = ringbuf_available(aica->frames);
-  int size = MIN(available, num_frames * 4);
-  CHECK_EQ(size % 4, 0);
-
-  ringbuf_advance_read_ptr(aica->frames, size);
-
-  return size / 4;
 }
 
 int aica_read_frames(struct aica *aica, void *frames, int num_frames) {

--- a/src/hw/aica/aica.c
+++ b/src/hw/aica/aica.c
@@ -391,6 +391,16 @@ static void aica_write_frames(struct aica *aica, const void *frames,
   }
 }
 
+int aica_skip_frames(struct aica *aica, int num_frames) {
+  int available = ringbuf_available(aica->frames);
+  int size = MIN(available, num_frames * 4);
+  CHECK_EQ(size % 4, 0);
+
+  ringbuf_advance_read_ptr(aica->frames, size);
+
+  return size / 4;
+}
+
 int aica_read_frames(struct aica *aica, void *frames, int num_frames) {
   int available = ringbuf_available(aica->frames);
   int size = MIN(available, num_frames * 4);

--- a/src/hw/aica/aica.h
+++ b/src/hw/aica/aica.h
@@ -7,6 +7,8 @@
 struct aica;
 struct dreamcast;
 
+#define AICA_SAMPLE_FREQ 44100
+
 AM_DECLARE(aica_reg_map);
 AM_DECLARE(aica_data_map);
 
@@ -14,7 +16,6 @@ struct aica *aica_create(struct dreamcast *dc);
 void aica_destroy(struct aica *aica);
 
 int aica_available_frames(struct aica *aica);
-int aica_skip_frames(struct aica *aica, int num_frames);
 int aica_read_frames(struct aica *aica, void *buffer, int num_frames);
 
 #endif

--- a/src/hw/aica/aica.h
+++ b/src/hw/aica/aica.h
@@ -14,6 +14,7 @@ struct aica *aica_create(struct dreamcast *dc);
 void aica_destroy(struct aica *aica);
 
 int aica_available_frames(struct aica *aica);
-int aica_read_frames(struct aica *aica, void *buffer, int size);
+int aica_skip_frames(struct aica *aica, int num_frames);
+int aica_read_frames(struct aica *aica, void *buffer, int num_frames);
 
 #endif

--- a/src/hw/pvr/ta.c
+++ b/src/hw/pvr/ta.c
@@ -733,11 +733,9 @@ static void ta_start_render(struct ta *ta, struct tile_ctx *ctx) {
   int num_polys = 0;
   ta_register_texture_sources(ta, ctx, &num_polys);
 
-  /* supposedly, the dreamcast can push around ~3 million polygons per second
-     through the TA / PVR. with that in mind, a very poor estimate can be made
-     for how long the TA would take to render a frame based on the number of
-     polys pushed: 1,000,000,000 / 3,000,000 = 333 nanoseconds per polygon */
-  int64_t ns = num_polys * INT64_C(333);
+  /* give each frame 10 ms to finish rendering
+     TODO figure out a heuristic involving the number of polygons rendered */
+  int64_t ns = INT64_C(10000000);
   scheduler_start_timer(ta->scheduler, &ta_render_timer, ta, ns);
 
   if (ta->trace_writer) {


### PR DESCRIPTION
Whenever there's not enough audio available for the audio backend, redream should emit silence to avoid a host audio underflow.

Not all soundio backends handle this gracefully and may result in long pauses instead of temporary stutters, which the latter is much more desirable.