### PR TITLE
Speed hackfixes: Arm underclock, no vram locks, track fastmem, no rc memset

### DIFF
--- a/src/hw/arm7/arm7.c
+++ b/src/hw/arm7/arm7.c
@@ -167,7 +167,7 @@ static void arm7_translate(void *data, uint32_t addr, struct ir *ir, int flags,
   ir_branch_true(ir, ir_alloc_ptr(ir, arm7_dispatch_interrupt), pending_intr);
 
   /* update remaining cycles */
-  int cycles = (size / 4);
+  int cycles = (size / 4) * 12;
   remaining_cycles = ir_sub(ir, remaining_cycles, ir_alloc_i32(ir, cycles));
   ir_store_context(ir, offsetof(struct armv3_context, remaining_cycles),
                    remaining_cycles);

--- a/src/hw/pvr/ta.c
+++ b/src/hw/pvr/ta.c
@@ -519,7 +519,7 @@ static void ta_register_texture_source(struct ta *ta, union tsp tsp,
     }
   }
 
-#ifdef NDEBUG
+#if 0
   /* add write callback in order to invalidate on future writes. the callback
      address will be page aligned, therefore it will be triggered falsely in
      some cases. over invalidate in these cases */

--- a/src/hw/pvr/tr.c
+++ b/src/hw/pvr/tr.c
@@ -939,7 +939,11 @@ static void tr_reset(struct tr *tr, struct render_context *rc) {
   tr->vertex_type = TA_NUM_VERTS;
 
   /* reset render context state */
-  memset(rc, 0, sizeof(*rc));
+  //memset(rc, 0, sizeof(*rc));
+  rc->num_params = 0;
+  rc->num_surfs = 0;
+  rc->num_verts = 0;
+  memset(rc->lists, 0, sizeof(rc->lists));
 }
 
 void tr_parse_context(struct tr *tr, const struct tile_ctx *ctx,

--- a/src/jit/backend/x64/x64_backend.cc
+++ b/src/jit/backend/x64/x64_backend.cc
@@ -539,6 +539,9 @@ static int x64_backend_handle_exception(struct jit_backend *base,
   ex->thread_state.rsp -= STACK_SHADOW_SPACE + 8 + 8;
   CHECK(ex->thread_state.rsp % 16 == 0);
 
+  printf("Guest access: %08X\n", guest_addr);
+
+
   if (mov.is_load) {
     /* prep argument registers (memory object, guest_addr) for read function */
     ex->thread_state.r[x64_arg0_idx] = reinterpret_cast<uint64_t>(guest->space);
@@ -1633,7 +1636,7 @@ struct x64_backend *x64_backend_create(struct jit *jit, void *code,
   backend->code_size = code_size;
   backend->stack_size = stack_size;
   backend->codegen = new Xbyak::CodeGenerator(code_size, code);
-  backend->use_avx = cpu.has(Xbyak::util::Cpu::tAVX);
+  backend->use_avx = cpu.has(Xbyak::util::Cpu::tAVX) && cpu.has(Xbyak::util::Cpu::tAVX2);
 
   int res = cs_open(CS_ARCH_X86, CS_MODE_64, &backend->capstone_handle);
   CHECK_EQ(res, CS_ERR_OK);


### PR DESCRIPTION
Probably you don't want the arm 12:1 underclock. Something like 2:1 or 4:1 is realistic given arm has no cache. I suspect the unneeded slowmems are from ccn cache resets that still leave the blocks in the cache (do they?). Also, vram invalidations seem to make blocks slowmem.