### PR TITLE
MMU: Add support for SQ remaps

### DIFF
--- a/src/guest/sh4/sh4.h
+++ b/src/guest/sh4/sh4.h
@@ -45,6 +45,9 @@ struct sh4 {
 #include "guest/sh4/sh4_regs.inc"
 #undef SH4_REG
 
+  uint32_t sq_tlb_remaps[64];
+  struct { union pteh high; union ptel low; } utlb[64];
+  
   /* jit */
   struct jit *jit;
   struct sh4_guest *guest;

--- a/src/guest/sh4/sh4_regs.inc
+++ b/src/guest/sh4/sh4_regs.inc
@@ -1,9 +1,9 @@
 /*      ADDR        NAME         DEFAULT     TYPE */
-SH4_REG(0xff000000, PTEH,        0x00000000, uint32_t)
-SH4_REG(0xff000004, PTEL,        0x00000000, uint32_t)
+SH4_REG(0xff000000, PTEH,        0x00000000, union pteh)
+SH4_REG(0xff000004, PTEL,        0x00000000, union ptel)
 SH4_REG(0xff000008, TTB,         0x00000000, uint32_t)
 SH4_REG(0xff00000c, TEA,         0x00000000, uint32_t)
-SH4_REG(0xff000010, MMUCR,       0x00000000, uint32_t)
+SH4_REG(0xff000010, MMUCR,       0x00000000, union mmucr)
 SH4_REG(0xff000014, BASRA,       0x00000000, uint32_t)
 SH4_REG(0xff000018, BASRB,       0x00000000, uint32_t)
 SH4_REG(0xff00001c, CCR,         0x00000000, union ccr)

--- a/src/guest/sh4/sh4_types.h
+++ b/src/guest/sh4/sh4_types.h
@@ -3,6 +3,52 @@
 
 #include <stdint.h>
 
+union pteh
+{
+  uint32_t full;
+	struct
+	{
+		uint32_t ASID : 8;
+		uint32_t reserved : 2;
+		uint32_t VPN : 22;
+	};
+};
+
+union ptel
+{
+  uint32_t full;
+	struct
+	{
+		uint32_t WT : 1;
+		uint32_t SH : 1;
+		uint32_t D : 1;
+		uint32_t C : 1;
+		uint32_t SZ0 : 1;
+		uint32_t PR : 2;
+		uint32_t SZ1 : 1;
+		uint32_t V : 1;
+		uint32_t reserved : 1;
+		uint32_t PPN : 19;
+		uint32_t reserved1 : 3;
+	};
+};
+
+union mmucr {
+  uint32_t full;
+  struct
+	{
+		uint32_t AT : 1;
+		uint32_t reserved : 1;
+		uint32_t TI : 1;
+		uint32_t reserved1 : 5;
+		uint32_t SV : 1;
+		uint32_t SQMD : 1;
+		uint32_t URC : 6;
+		uint32_t URB : 6;
+		uint32_t LRUI : 6;
+	};
+};
+
 union ccr {
   uint32_t full;
   struct {

--- a/src/jit/frontend/sh4/sh4_fallback.c
+++ b/src/jit/frontend/sh4/sh4_fallback.c
@@ -387,6 +387,8 @@ typedef int32_t int128_t[4];
 
 #define SLEEP()                     guest->sleep(guest->data)
 
+#define LDTLB()                     guest->ldtlb(guest->data)
+
 /* clang-format on */
 
 #define INSTR(name)                                                \

--- a/src/jit/frontend/sh4/sh4_guest.h
+++ b/src/jit/frontend/sh4/sh4_guest.h
@@ -12,6 +12,7 @@ struct sh4_guest {
   void (*sleep)(void *);
   void (*sr_updated)(void *, uint32_t);
   void (*fpscr_updated)(void *, uint32_t);
+  void (*ldtlb)(void *);
 };
 
 static inline struct sh4_guest *sh4_guest_create() {

--- a/src/jit/frontend/sh4/sh4_instr.h
+++ b/src/jit/frontend/sh4/sh4_instr.h
@@ -1379,6 +1379,11 @@ INSTR(SLEEP) {
   SLEEP();
 }
 
+/* LDTLB */
+INSTR(LDTLB) {
+  LDTLB();
+}
+
 /* STC     SR,Rn */
 INSTR(STCSR) {
   I32 v = LOAD_SR_I32();

--- a/src/jit/frontend/sh4/sh4_instr.inc
+++ b/src/jit/frontend/sh4/sh4_instr.inc
@@ -135,6 +135,7 @@ SH4_INSTR(RTS,       "rts",                          0000000000001011, 2, SH4_FL
 
 
 // system control instructions
+SH4_INSTR(LDTLB,     "ldtlb",                        0000000000111000, 1, 0)
 SH4_INSTR(CLRMAC,    "clrmac",                       0000000000101000, 1, 0)
 SH4_INSTR(CLRS,      "clrs",                         0000000001001000, 1, 0)
 SH4_INSTR(CLRT,      "clrt",                         0000000000001000, 1, 0)

--- a/src/jit/frontend/sh4/sh4_translate.c
+++ b/src/jit/frontend/sh4/sh4_translate.c
@@ -441,6 +441,12 @@ static void store_fpscr(struct sh4_guest *guest, struct ir *ir,
                                       struct ir_value *data = ir_alloc_i64(ir, (uint64_t)guest->data);   \
                                       ir_call_1(ir, sleep, data);                                        \
                                     }
+                                    
+#define LDTLB()                     {                                                                    \
+                                      struct ir_value *ldtlb = ir_alloc_i64(ir, (uint64_t)guest->ldtlb); \
+                                      struct ir_value *data = ir_alloc_i64(ir, (uint64_t)guest->data);   \
+                                      ir_call_1(ir, ldtlb, data);                                        \
+                                    }
 
 /* clang-format on */
 


### PR DESCRIPTION
- Add mmucr, ptel, pteh unions
- Improved p4 memmap, add IC/OC/ITLB/UTLB stubs
- Implement basic UTLB writes to make Katana sdk r11+ happy
- Implement limited sq remapping to make Katana sdk r11+ happy (1 meg pages)
- Implement ldtlb (this wasn't needed after all, but was easy)

To do
- Cleanup the code a bit. 
- Clang format?
- Maybe remove ldtlb? I don't think anything non-wince uses it
- Add more checks in the sq remapping logic? (eg, validate 1 meg page size)