### PR TITLE
Libretro static Makefile

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,216 @@
+INCFLAGS += \
+	-I$(CORE_DIR)/src \
+	-I$(CORE_DIR)/deps/capstone/include \
+	-I$(CORE_DIR)/deps/inih \
+	-I$(CORE_DIR)/deps/dirent-1.21 \
+	-I$(CORE_DIR)/deps/xbyak-4.901 \
+	-I$(CORE_DIR)/deps/libretro/include \
+	-I$(CORE_DIR)/deps/glad/include \
+	-I$(LIBRETRO_DIR)
+
+#SOURCES_CXX := $(CORE_DIR)/src/render/microprofile.cc
+#INCFLAGS += -I$(CORE_DIR)/deps/microprofile \
+
+SOURCES_CXX := 
+SOURCES_CPP :=
+
+ifeq ($(HAVE_IMGUI), 1)
+INCFLAGS += -I$(CORE_DIR)/deps/cimgui
+SOURCES_CXX += $(CORE_DIR)/src/render/imgui.cc \
+SOURCES_CPP += $(CORE_DIR)/deps/cimgui/cimgui/cimgui.cpp
+endif
+
+SOURCES_C   := $(CORE_DIR)/src/core/assert.c \
+					$(CORE_DIR)/src/file/trace.c \
+					$(CORE_DIR)/src/core/filesystem.c \
+					$(CORE_DIR)/src/core/interval_tree.c \
+					$(CORE_DIR)/src/core/exception_handler.c \
+					$(CORE_DIR)/src/core/list.c \
+					$(CORE_DIR)/src/core/log.c \
+					$(CORE_DIR)/src/core/md5.c \
+					$(CORE_DIR)/src/core/ringbuf.c \
+					$(CORE_DIR)/src/core/rb_tree.c \
+					$(CORE_DIR)/src/core/sort.c \
+					$(CORE_DIR)/src/core/profiler.c \
+					$(CORE_DIR)/src/core/string.c \
+					 \
+					$(CORE_DIR)/src/guest/bios/bios.c \
+					$(CORE_DIR)/src/guest/bios/flash.c \
+					$(CORE_DIR)/src/guest/bios/syscalls.c \
+					$(CORE_DIR)/src/guest/gdrom/cdi.c \
+					$(CORE_DIR)/src/guest/gdrom/disc.c \
+					$(CORE_DIR)/src/guest/gdrom/gdi.c \
+					$(CORE_DIR)/src/guest/gdrom/gdrom.c \
+					$(CORE_DIR)/src/guest/holly/holly.c \
+					$(CORE_DIR)/src/guest/maple/controller.c \
+					$(CORE_DIR)/src/guest/maple/maple.c \
+					$(CORE_DIR)/src/guest/maple/vmu.c \
+					$(CORE_DIR)/src/guest/pvr/pvr.c \
+					$(CORE_DIR)/src/guest/pvr/ta.c \
+					$(CORE_DIR)/src/guest/pvr/tr.c \
+					$(CORE_DIR)/src/guest/aica/aica.c \
+					$(CORE_DIR)/src/guest/arm7/arm7.c \
+					$(CORE_DIR)/src/guest/rom/boot.c \
+					$(CORE_DIR)/src/guest/rom/flash.c \
+					$(CORE_DIR)/src/guest/sh4/sh4.c \
+					$(CORE_DIR)/src/guest/sh4/sh4_ccn.c \
+					$(CORE_DIR)/src/guest/sh4/sh4_dbg.c \
+					$(CORE_DIR)/src/guest/sh4/sh4_dmac.c \
+					$(CORE_DIR)/src/guest/sh4/sh4_intc.c \
+					$(CORE_DIR)/src/guest/sh4/sh4_mmu.c \
+					$(CORE_DIR)/src/guest/sh4/sh4_tmu.c \
+					$(CORE_DIR)/src/guest/dreamcast.c \
+					$(CORE_DIR)/src/guest/memory.c \
+					$(CORE_DIR)/src/guest/scheduler.c \
+					$(CORE_DIR)/src/core/option.c \
+					$(CORE_DIR)/src/core/memory.c \
+					$(CORE_DIR)/deps/inih/ini.c \
+					$(CORE_DIR)/src/host/keycode.c \
+					$(CORE_DIR)/src/jit/backend/interp/interp_backend.c \
+					$(CORE_DIR)/src/jit/frontend/armv3/armv3_context.c \
+					$(CORE_DIR)/src/jit/frontend/armv3/armv3_disasm.c \
+					$(CORE_DIR)/src/jit/frontend/armv3/armv3_fallback.c \
+					$(CORE_DIR)/src/jit/frontend/armv3/armv3_frontend.c \
+					$(CORE_DIR)/src/jit/frontend/sh4/sh4_disasm.c \
+					$(CORE_DIR)/src/jit/frontend/sh4/sh4_fallback.c \
+					$(CORE_DIR)/src/jit/frontend/sh4/sh4_frontend.c \
+					$(CORE_DIR)/src/jit/frontend/sh4/sh4_translate.c \
+					$(CORE_DIR)/src/jit/ir/ir.c \
+					$(CORE_DIR)/src/jit/ir/ir_read.c \
+					$(CORE_DIR)/src/jit/ir/ir_write.c \
+					$(CORE_DIR)/src/jit/passes/constant_propagation_pass.c \
+					$(CORE_DIR)/src/jit/passes/control_flow_analysis_pass.c \
+					$(CORE_DIR)/src/jit/passes/conversion_elimination_pass.c \
+					$(CORE_DIR)/src/jit/passes/dead_code_elimination_pass.c \
+					$(CORE_DIR)/src/jit/passes/expression_simplification_pass.c \
+					$(CORE_DIR)/src/jit/passes/load_store_elimination_pass.c \
+					$(CORE_DIR)/src/jit/passes/register_allocation_pass.c \
+					$(CORE_DIR)/src/jit/jit.c \
+					$(CORE_DIR)/src/jit/pass_stats.c \
+					$(CORE_DIR)/src/emulator.c \
+					$(CORE_DIR)/src/tracer.c \
+					$(CORE_DIR)/src/guest/debugger.c \
+					$(CORE_DIR)/src/host/retro_host.c
+
+SOURCES_C 	+=	$(CORE_DIR)/src/render/gl_backend.c
+
+SOURCES_C   += $(CORE_DIR)/deps/capstone/cs.c \
+					$(CORE_DIR)/deps/capstone/utils.c \
+					$(CORE_DIR)/deps/capstone/MCInst.c \
+					$(CORE_DIR)/deps/capstone/MCInstrDesc.c \
+					$(CORE_DIR)/deps/capstone/MCRegisterInfo.c \
+					$(CORE_DIR)/deps/capstone/SStream.c \
+
+ifeq ($(CAPSTONE_HAS_ARM), 1)
+					$(CORE_DIR)/deps/capstone/arch/ARM/ARMDisassembler.c \
+					$(CORE_DIR)/deps/capstone/arch/ARM/ARMInstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/ARM/ARMMapping.c \
+					$(CORE_DIR)/deps/capstone/arch/ARM/ARMModule.c
+endif
+
+ifeq ($(CAPSTONE_HAS_ARM64), 1)
+SOURCES_C += 	$(CORE_DIR)/deps/capstone/arch/AArch64/AArch64Disassembler.c \
+					$(CORE_DIR)/deps/capstone/arch/AArch64/AArch64InstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/AArch64/AArch64Mapping.c \
+					$(CORE_DIR)/deps/capstone/arch/AArch64/AArch64BaseInfo.c \
+					$(CORE_DIR)/deps/capstone/arch/AArch64/AArch64Module.c
+endif
+
+SOURCES_C +=	$(CORE_DIR)/deps/capstone/arch/Mips/MipsDisassembler.c \
+					$(CORE_DIR)/deps/capstone/arch/Mips/MipsInstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/Mips/MipsMapping.c \
+					$(CORE_DIR)/deps/capstone/arch/Mips/MipsModule.c
+
+ifeq ($(CAPSTONE_HAS_POWERPC), 1)
+SOURCES_C +=	$(CORE_DIR)/deps/capstone/arch/PowerPC/PPCDisassembler.c \
+					$(CORE_DIR)/deps/capstone/arch/PowerPC/PPCInstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/PowerPC/PPCMapping.c \
+					$(CORE_DIR)/deps/capstone/arch/PowerPC/PPCModule.c
+endif
+
+SOURCES_C +=	$(CORE_DIR)/deps/capstone/arch/X86/X86Disassembler.c \
+					$(CORE_DIR)/deps/capstone/arch/X86/X86DisassemblerDecoder.c \
+					$(CORE_DIR)/deps/capstone/arch/X86/X86ATTInstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/X86/X86IntelInstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/X86/X86Mapping.c \
+					$(CORE_DIR)/deps/capstone/arch/X86/X86Module.c
+
+ifeq ($(CAPSTONE_HAS_SPARC), 1)
+SOURCES_C +=	$(CORE_DIR)/deps/capstone/arch/Sparc/SparcDisassembler.c \
+					$(CORE_DIR)/deps/capstone/arch/Sparc/SparcInstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/Sparc/SparcMapping.c \
+					$(CORE_DIR)/deps/capstone/arch/Sparc/SparcModule.c
+endif
+
+ifeq ($(CAPSTONE_HAS_SYSTEMZ), 1)
+SOURCES_C +=	$(CORE_DIR)/deps/capstone/arch/SystemZ/SystemZDisassembler.c \
+					$(CORE_DIR)/deps/capstone/arch/SystemZ/SystemZInstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/SystemZ/SystemZMapping.c \
+					$(CORE_DIR)/deps/capstone/arch/SystemZ/SystemZMCTargetDesc.c \
+					$(CORE_DIR)/deps/capstone/arch/SystemZ/SystemZModule.c
+endif
+
+ifeq ($(CAPSTONE_HAS_XCORE), 1)
+SOURCES_C +=	$(CORE_DIR)/deps/capstone/arch/XCore/XCoreDisassembler.c \
+					$(CORE_DIR)/deps/capstone/arch/XCore/XCoreInstPrinter.c \
+					$(CORE_DIR)/deps/capstone/arch/XCore/XCoreMapping.c \
+					$(CORE_DIR)/deps/capstone/arch/XCore/XCoreModule.c
+endif
+
+ifeq ($(HAVE_LINUX), 1)
+SOURCES_C += $(CORE_DIR)/src/core/exception_handler_linux.c  \
+				 $(CORE_DIR)/src/core/time_linux.c 
+endif
+
+ifeq ($(HAVE_MAC), 1)
+SOURCES_C += $(CORE_DIR)/src/core/exception_handler_mac.c  \
+				 $(CORE_DIR)/src/core/time_mac.c 
+endif
+
+ifeq ($(HAVE_WINDOWS), 1)
+SOURCES_C += $(CORE_DIR)/src/core/exception_handler_win.c  \
+				 $(CORE_DIR)/src/core/time_win.c 
+endif
+
+ifeq ($(HAVE_POSIX), 1)
+SOURCES_C += $(CORE_DIR)/src/core/filesystem_posix.c \
+				 $(CORE_DIR)/src/core/memory_posix.c \
+				 $(CORE_DIR)/src/core/thread_posix.c
+endif
+
+ifeq ($(HAVE_WINDOWS), 1)
+SOURCES_C += $(CORE_DIR)/src/core/filesystem_win.c \
+				 $(CORE_DIR)/src/core/memory_win.c \
+				 $(CORE_DIR)/src/core/thread_win.c
+endif
+
+SOURCES_C += $(CORE_DIR)/deps/glad/src/glad.c
+
+ifdef WITH_DYNAREC
+
+	ifeq ($(WITH_DYNAREC), arm)
+		DYNAFLAGS += -DNEW_DYNAREC=3
+	endif
+
+	ifeq ($(WITH_DYNAREC), x86)
+		DYNAFLAGS += -D_M_IX86
+	endif
+
+	ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), x86_64 x64))
+	   COREFLAGS += -DARCH_X64=1
+		DYNAFLAGS += -D_M_X64
+	endif
+
+ifeq ($(WITH_DYNAREC), arm)
+endif
+ifeq ($(WITH_DYNAREC), $(filter $(WITH_DYNAREC), x86_64 x64))
+		DYNAREC_USED = 1
+		CPUFLAGS += -msse -msse2
+		SOURCES_CXX += \
+			       $(CORE_DIR)/src/jit/backend/x64/x64_backend.cc \
+			       $(CORE_DIR)/src/jit/backend/x64/x64_dispatch.cc \
+			       $(CORE_DIR)/src/jit/backend/x64/x64_emitters.cc
+		SOURCES_C += $(CORE_DIR)/src/jit/backend/x64/x64_disassembler.c
+endif
+
+endif

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,0 +1,509 @@
+DEBUG=0
+PERF_TEST=0
+HAVE_SHARED_CONTEXT=0
+FORCE_GLES=0
+HAVE_OPENGL=1
+HAVE_LINUX :=
+HAVE_MAC :=
+HAVE_WINDOWS :=
+
+DYNAFLAGS :=
+INCFLAGS  :=
+COREFLAGS :=
+CPUFLAGS  :=
+GLFLAGS   :=
+
+CAPSTONE_HAS_ARM=0
+CAPSTONE_HAS_ARM64=0
+CAPSTONE_HAS_POWERPC=0
+CAPSTONE_HAS_SPARC=0
+CAPSTONE_HAS_SYSTEMZ=0
+CAPSTONE_HAS_XCORE=0
+
+UNAME=$(shell uname -a)
+
+# Dirs
+ROOT_DIR := .
+CORE_DIR := .
+LIBRETRO_DIR := $(ROOT_DIR)/deps/libretro
+
+ifeq ($(platform),)
+   platform = unix
+   ifeq ($(UNAME),)
+      platform = win
+   else ifneq ($(findstring MINGW,$(UNAME)),)
+      platform = win
+   else ifneq ($(findstring Darwin,$(UNAME)),)
+      platform = osx
+   else ifneq ($(findstring win,$(UNAME)),)
+      platform = win
+   endif
+else ifneq (,$(findstring armv,$(platform)))
+   override platform += unix
+else ifneq (,$(findstring rpi,$(platform)))
+   override platform += unix
+else ifneq (,$(findstring odroid,$(platform)))
+   override platform += unix
+endif
+
+# system platform
+system_platform = unix
+ifeq ($(shell uname -a),)
+   EXE_EXT = .exe
+   system_platform = win
+else ifneq ($(findstring Darwin,$(shell uname -a)),)
+   system_platform = osx
+   arch = intel
+ifeq ($(shell uname -p),powerpc)
+   arch = ppc
+endif
+else ifneq ($(findstring MINGW,$(shell uname -a)),)
+   system_platform = win
+endif
+
+# Cross compile ?
+
+ifeq (,$(ARCH))
+   ARCH = $(shell uname -m)
+endif
+
+# Target Dynarec
+WITH_DYNAREC = $(ARCH)
+
+ifeq ($(ARCH), $(filter $(ARCH), x86_64 x64))
+   WITH_DYNAREC = x64
+else ifeq ($(ARCH), $(filter $(ARCH), i386 i686))
+   WITH_DYNAREC = x86
+else ifeq ($(ARCH), $(filter $(ARCH), arm))
+   WITH_DYNAREC = arm
+endif
+
+TARGET_NAME := redream
+
+CC_AS ?= $(CC)
+
+GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	COREFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
+# Unix
+ifneq (,$(findstring unix,$(platform)))
+   TARGET := $(TARGET_NAME)_libretro.so
+   LDFLAGS += -shared -Wl,--no-undefined
+	ifeq ($(DEBUG_JIT),)
+	   LDFLAGS += -Wl,--version-script=$(LIBRETRO_DIR)/link.T
+	endif
+   fpic = -fPIC
+	HAVE_LINUX = 1
+	HAVE_POSIX = 1
+	LDFLAGS    += -lrt
+	LDFLAGS    += -lpthread
+
+   ifeq ($(FORCE_GLES),1)
+      GLES = 1
+      GL_LIB := -lGLESv2
+   else ifneq (,$(findstring gles,$(platform)))
+      GLES = 1
+      GL_LIB := -lGLESv2
+   else
+      GL_LIB := -lGL
+   endif
+
+   # Raspberry Pi
+   ifneq (,$(findstring rpi,$(platform)))
+      GLES = 1
+      GL_LIB := -L/opt/vc/lib -lGLESv2
+      INCFLAGS += -I/opt/vc/include
+      WITH_DYNAREC=arm
+      ifneq (,$(findstring rpi2,$(platform)))
+         CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+         CPUFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+         HAVE_NEON = 1
+      else ifneq (,$(findstring rpi3,$(platform)))
+         CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+         CPUFLAGS += -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
+         HAVE_NEON = 1
+      else
+         CPUFLAGS += -DARMv5_ONLY -DNO_ASM
+      endif
+   endif
+
+   # ODROIDs
+   ifneq (,$(findstring odroid,$(platform)))
+      BOARD := $(shell cat /proc/cpuinfo | grep -i odroid | awk '{print $$3}')
+      GLES = 1
+      GL_LIB := -lGLESv2
+      CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+      CPUFLAGS += -marm -mfloat-abi=hard
+      HAVE_NEON = 1
+      WITH_DYNAREC=arm
+      ifneq (,$(findstring ODROIDC,$(BOARD)))
+         # ODROID-C1
+         CPUFLAGS += -mcpu=cortex-a5 -mfpu=neon
+      else ifneq (,$(findstring ODROID-XU3,$(BOARD)))
+         # ODROID-XU4, XU3 & XU3 Lite
+         ifeq "$(shell expr `gcc -dumpversion` \>= 4.9)" "1"
+            CPUFLAGS += -march=armv7ve -mcpu=cortex-a15.cortex-a7 -mfpu=neon-vfpv4
+         else
+            CPUFLAGS += -mcpu=cortex-a9 -mfpu=neon
+         endif
+      else
+         # ODROID-U3, U2, X2 & X
+         CPUFLAGS += -mcpu=cortex-a9 -mfpu=neon
+      endif
+   endif
+
+   # Generic ARM
+   ifneq (,$(findstring armv,$(platform)))
+      CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -DNOSSE
+      WITH_DYNAREC=arm
+      ifneq (,$(findstring neon,$(platform)))
+         CPUFLAGS += -D__NEON_OPT -mfpu=neon
+         HAVE_NEON = 1
+      endif
+   endif
+
+   PLATFORM_EXT := unix
+
+# i.MX6
+else ifneq (,$(findstring imx6,$(platform)))
+   TARGET := $(TARGET_NAME)_libretro.so
+   LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T
+   fpic = -fPIC
+   GLES = 1
+   GL_LIB := -lGLESv2
+   CPUFLAGS += -DNO_ASM
+   PLATFORM_EXT := unix
+   WITH_DYNAREC=arm
+   HAVE_NEON=1
+
+# OS X
+else ifneq (,$(findstring osx,$(platform)))
+   TARGET := $(TARGET_NAME)_libretro.dylib
+   LDFLAGS += -dynamiclib
+   OSXVER = `sw_vers -productVersion | cut -d. -f 2`
+   OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
+        LDFLAGS += -mmacosx-version-min=10.7
+   LDFLAGS += -stdlib=libc++
+	LDFLAGS    += -lpthread
+   fpic = -fPIC
+	HAVE_MAC = 1
+	HAVE_POSIX = 1
+
+   PLATCFLAGS += -D__MACOSX__ -DOSX
+   GL_LIB := -framework OpenGL
+   PLATFORM_EXT := unix
+
+   # Target Dynarec
+   ifeq ($(ARCH), $(filter $(ARCH), ppc))
+      WITH_DYNAREC =
+   endif
+
+# iOS
+else ifneq (,$(findstring ios,$(platform)))
+   ifeq ($(IOSSDK),)
+      IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
+   endif
+
+   TARGET := $(TARGET_NAME)_libretro_ios.dylib
+   DEFINES += -DIOS
+   GLES = 1
+	WITH_DYNAREC=arm
+   PLATFORM_EXT := unix
+
+   PLATCFLAGS += -DHAVE_POSIX_MEMALIGN -DNO_ASM
+   PLATCFLAGS += -DIOS -marm
+   CPUFLAGS += -DNO_ASM  -DARM -D__arm__ -DARM_ASM -D__NEON_OPT
+   CPUFLAGS += -marm -mcpu=cortex-a8 -mfpu=neon -mfloat-abi=softfp
+   LDFLAGS += -dynamiclib
+   HAVE_NEON=1
+
+   fpic = -fPIC
+   GL_LIB := -framework OpenGLES
+
+   CC = clang -arch armv7 -isysroot $(IOSSDK)
+   CC_AS = perl ./tools/gas-preprocessor.pl $(CC)
+   CXX = clang++ -arch armv7 -isysroot $(IOSSDK)
+   ifeq ($(platform),ios9)
+      CC         += -miphoneos-version-min=8.0
+      CC_AS      += -miphoneos-version-min=8.0
+      CXX        += -miphoneos-version-min=8.0
+      PLATCFLAGS += -miphoneos-version-min=8.0
+   else
+      CC += -miphoneos-version-min=5.0
+      CC_AS += -miphoneos-version-min=5.0
+      CXX += -miphoneos-version-min=5.0
+      PLATCFLAGS += -miphoneos-version-min=5.0
+   endif
+
+# Theos iOS
+else ifneq (,$(findstring theos_ios,$(platform)))
+   DEPLOYMENT_IOSVERSION = 5.0
+   TARGET = iphone:latest:$(DEPLOYMENT_IOSVERSION)
+   ARCHS = armv7
+   TARGET_IPHONEOS_DEPLOYMENT_VERSION=$(DEPLOYMENT_IOSVERSION)
+   THEOS_BUILD_DIR := objs
+   include $(THEOS)/makefiles/common.mk
+
+   LIBRARY_NAME = $(TARGET_NAME)_libretro_ios
+   DEFINES += -DIOS
+   GLES = 1
+   WITH_DYNAREC=arm
+
+   PLATCFLAGS += -DHAVE_POSIX_MEMALIGN -DNO_ASM
+   PLATCFLAGS += -DIOS -marm
+   CPUFLAGS += -DNO_ASM  -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+   HAVE_NEON=1
+
+
+# Android
+else ifneq (,$(findstring android,$(platform)))
+   fpic = -fPIC
+   TARGET := $(TARGET_NAME)_libretro_android.so
+   LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined -Wl,--warn-common
+   GL_LIB := -lGLESv2
+
+   CC = arm-linux-androideabi-gcc
+   CXX = arm-linux-androideabi-g++
+   WITH_DYNAREC=arm
+   GLES = 1
+   PLATCFLAGS += -DANDROID
+   CPUCFLAGS  += -DNO_ASM
+   HAVE_NEON = 1
+   CPUFLAGS += -marm -mcpu=cortex-a8 -mfpu=neon -mfloat-abi=softfp -D__arm__ -DARM_ASM -D__NEON_OPT
+   CFLAGS += -DANDROID
+
+   PLATFORM_EXT := unix
+
+# QNX
+else ifeq ($(platform), qnx)
+   fpic = -fPIC
+   TARGET := $(TARGET_NAME)_libretro_$(platform).so
+   LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined -Wl,--warn-common
+   GL_LIB := -lGLESv2
+
+   CC = qcc -Vgcc_ntoarmv7le
+   CC_AS = qcc -Vgcc_ntoarmv7le
+   CXX = QCC -Vgcc_ntoarmv7le
+   AR = QCC -Vgcc_ntoarmv7le
+   WITH_DYNAREC=arm
+   GLES = 1
+   PLATCFLAGS += -DNO_ASM -D__BLACKBERRY_QNX__
+   CPUFLAGS += -DNOSSE
+   HAVE_NEON = 1
+   CPUFLAGS += -marm -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=softfp -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
+   CFLAGS += -D__QNX__
+
+   PLATFORM_EXT := unix
+
+# emscripten
+else ifeq ($(platform), emscripten)
+   TARGET := $(TARGET_NAME)_libretro_$(platform).bc
+   GLES := 1
+   WITH_DYNAREC :=
+
+   CPUFLAGS += -DNOSSE
+   CPUFLAGS += -DEMSCRIPTEN -DNO_ASM -s USE_ZLIB=1
+   PLATCFLAGS += \
+      -Dsinc_resampler=mupen_sinc_resampler \
+      -DCC_resampler=mupen_CC_resampler \
+      -Drglgen_symbol_map=mupen_rglgen_symbol_map \
+      -Drglgen_resolve_symbols_custom=mupen_rglgen_resolve_symbols_custom \
+      -Drglgen_resolve_symbols=mupen_rglgen_resolve_symbols \
+      -Dmemalign_alloc=mupen_memalign_alloc \
+      -Dmemalign_free=mupen_memalign_free \
+      -Dmemalign_alloc_aligned=mupen_memalign_alloc_aligned \
+      -Daudio_resampler_driver_find_handle=mupen_audio_resampler_driver_find_handle \
+      -Daudio_resampler_driver_find_ident=mupen_audio_resampler_driver_find_ident \
+      -Drarch_resampler_realloc=mupen_rarch_resampler_realloc \
+      -Dconvert_float_to_s16_C=mupen_convert_float_to_s16_C \
+      -Dconvert_float_to_s16_init_simd=mupen_convert_float_to_s16_init_simd \
+      -Dconvert_s16_to_float_C=mupen_convert_s16_to_float_C \
+      -Dconvert_s16_to_float_init_simd=mupen_convert_s16_to_float_init_simd \
+      -Dcpu_features_get_perf_counter=mupen_cpu_features_get_perf_counter \
+      -Dcpu_features_get_time_usec=mupen_cpu_features_get_time_usec \
+      -Dcpu_features_get_core_amount=mupen_cpu_features_get_core_amount \
+      -Dcpu_features_get=mupen_cpu_features_get \
+      -Dffs=mupen_ffs \
+      -Dstrlcpy_retro__=mupen_strlcpy_retro__ \
+      -Dstrlcat_retro__=mupen_strlcat_retro__
+
+
+   WITH_DYNAREC =
+	CC = emcc
+   CXX = em++
+   HAVE_NEON = 0
+   PLATFORM_EXT := unix
+	STATIC_LINKING=1
+   #HAVE_SHARED_CONTEXT := 1
+
+# PlayStation Vita
+else ifneq (,$(findstring vita,$(platform)))
+   TARGET:= $(TARGET_NAME)_libretro_$(platform).a
+   CPUFLAGS += -DNO_ASM  -DARM -D__arm__ -DARM_ASM -D__NEON_OPT
+   CPUFLAGS += -w -mthumb -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard -D__arm__ -DARM_ASM -D__NEON_OPT -g
+   HAVE_NEON = 1
+
+   PREFIX = arm-vita-eabi
+   CC = $(PREFIX)-gcc
+   CXX = $(PREFIX)-g++
+   AR  = $(PREFIX)-ar
+   WITH_DYNAREC = arm
+   DYNAREC_USED = 0
+   GLES = 0
+   HAVE_OPENGL = 0
+   PLATCFLAGS += -DVITA
+   CPUCFLAGS += -DNO_ASM
+   CFLAGS += -DVITA -lm
+   VITA = 1
+
+   PLATFORM_EXT := unix
+   STATIC_LINKING=1
+
+# Windows
+else ifneq (,$(findstring win,$(platform)))
+   TARGET := $(TARGET_NAME)_libretro.dll
+	HAVE_WINDOWS = 1
+   LDFLAGS += -shared -static-libgcc -static-libstdc++ -Wl,--version-script=$(LIBRETRO_DIR)/link.T -lwinmm -lgdi32 -lUserenv
+	LDFLAGS    += -lpthread
+	COREFLAGS += -D__STDC_FORMAT_MACROS
+   GL_LIB := -lopengl32
+   PLATFORM_EXT := win32
+   CC = gcc
+   CXX = g++
+endif
+
+ifneq ($(SANITIZER),)
+    CFLAGS   += -fsanitize=$(SANITIZER)
+    CXXFLAGS += -fsanitize=$(SANITIZER)
+    LDFLAGS  += -fsanitize=$(SANITIZER)
+endif
+
+ifeq ($(HAVE_LINUX), 1)
+	COREFLAGS += -DPLATFORM_LINUX
+endif
+
+ifeq ($(HAVE_MAC), 1)
+	COREFLAGS += -DPLATFORM_DARWIN
+endif
+
+ifeq ($(HAVE_WINDOWS), 1)
+	COREFLAGS += -DPLATFORM_WINDOWS
+endif
+
+COREFLAGS += -D__LIBRETRO__ -D_GNU_SOURCE -DGLEW_STATIC -DGLEW_NO_GLU -DHAVE_STRCASECMP
+
+ifeq ($(CAPSTONE_HAS_ARM), 1)
+COREFLAGS += -DCAPSTONE_HAS_ARM
+endif
+
+ifeq ($(CAPSTONE_HAS_ARM64), 1)
+COREFLAGS += -DCAPSTONE_HAS_ARM64
+endif
+
+COREFLAGS += -DCAPSTONE_HAS_MIPS
+
+ifeq ($(CAPSTONE_HAS_POWERPC), 1)
+COREFLAGS += -DCAPSTONE_HAS_POWERPC
+endif
+
+ifeq ($(CAPSTONE_HAS_SPARC), 1)
+COREFLAGS += -DCAPSTONE_HAS_SPARC
+endif
+
+ifeq ($(CAPSTONE_HAS_SYSTEMZ), 1)
+COREFLAGS += -DCAPSTONE_HAS_SYSZ
+endif
+
+COREFLAGS += -DCAPSTONE_HAS_X86
+
+ifeq ($(CAPSTONE_HAS_XCORE), 1)
+COREFLAGS += -DCAPSTONE_HAS_XCORE
+endif
+
+COREFLAGS += -DCAPSTONE_USE_SYS_DYN_MEM
+COREFLAGS += -fms-extensions
+
+include Makefile.common
+
+ifeq ($(HAVE_NEON), 1)
+   COREFLAGS += -DHAVE_NEON
+endif
+
+ifeq ($(PERF_TEST), 1)
+   COREFLAGS += -DPERF_TEST
+endif
+
+ifeq ($(HAVE_SHARED_CONTEXT), 1)
+   COREFLAGS += -DHAVE_SHARED_CONTEXT
+endif
+
+ifeq ($(DEBUG), 1)
+   CPUOPTS += -O0 -g
+   CPUOPTS += -DOPENGL_DEBUG
+else
+   CPUOPTS += -O2 -DNDEBUG
+endif
+
+ifeq ($(platform), qnx)
+   CFLAGS   += -Wp,-MMD
+   CXXFLAGS += -Wp,-MMD
+else
+ifeq ($(platform), emscripten)
+   CFLAGS   += -std=gnu11 -MMD
+else
+   CFLAGS   += -std=gnu11 -MMD
+endif
+CXXFLAGS += -std=gnu++11 -MMD
+ifeq ($(GLIDEN64CORE),1)
+   CFLAGS += -DCORE
+   CXXFLAGS += -DCORE
+endif
+endif
+
+### Finalize ###
+OBJECTS     += $(SOURCES_CXX:.cc=.o) $(SOURCES_CPP:.cpp=.o) $(SOURCES_C:.c=.o) $(SOURCES_ASM:.S=.o)
+CXXFLAGS    += $(CPUOPTS) $(COREFLAGS) $(INCFLAGS) $(PLATCFLAGS) $(fpic) $(PLATCFLAGS) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
+CFLAGS      += $(CPUOPTS) $(COREFLAGS) $(INCFLAGS) $(PLATCFLAGS) $(fpic) $(PLATCFLAGS) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
+
+ifeq ($(findstring Haiku,$(UNAME)),)
+   LDFLAGS += -lm
+endif
+
+LDFLAGS    += $(fpic)
+
+ifeq ($(platform), theos_ios)
+COMMON_FLAGS := -DIOS $(COMMON_DEFINES) $(INCFLAGS) -I$(THEOS_INCLUDE_PATH) -Wno-error
+$(LIBRARY_NAME)_ASFLAGS += $(CFLAGS) $(COMMON_FLAGS)
+$(LIBRARY_NAME)_CFLAGS += $(CFLAGS) $(COMMON_FLAGS)
+$(LIBRARY_NAME)_CXXFLAGS += $(CXXFLAGS) $(COMMON_FLAGS)
+${LIBRARY_NAME}_FILES = $(SOURCES_CXX) $(SOURCES_CPP) $(SOURCES_C) $(SOURCES_ASM)
+${LIBRARY_NAME}_FRAMEWORKS = OpenGLES
+${LIBRARY_NAME}_LIBRARIES = z
+include $(THEOS_MAKE_PATH)/library.mk
+else
+all: $(TARGET)
+$(TARGET): $(OBJECTS)
+ifeq ($(STATIC_LINKING), 1)
+	$(AR) rcs $@ $(OBJECTS)
+else
+	$(CXX) -o $@ $(OBJECTS) $(LDFLAGS) $(GL_LIB)
+endif
+
+%.o: %.S
+	$(CC_AS) $(CFLAGS) -c $< -o $@
+
+%.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+%.o: %.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+
+
+clean:
+	rm -f $(OBJECTS) $(TARGET) $(OBJECTS:.o=.d)
+
+.PHONY: clean
+-include $(OBJECTS:.o=.d)
+endif

--- a/deps/libretro/link.T
+++ b/deps/libretro/link.T
@@ -1,0 +1,5 @@
+{
+   global: retro_*;
+   local: *;
+};
+

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -31,7 +31,9 @@
 #include "guest/scheduler.h"
 #include "guest/sh4/sh4.h"
 #include "host/host.h"
+#ifdef HAVE_IMGUI
 #include "render/imgui.h"
+#endif
 #include "render/microprofile.h"
 #include "render/render_backend.h"
 
@@ -72,7 +74,9 @@ struct emu {
   volatile unsigned frame;
 
   struct render_backend *r;
+#ifdef HAVE_IMGUI
   struct imgui *imgui;
+#endif
   struct microprofile *mp;
   struct trace_writer *trace_writer;
 
@@ -415,8 +419,12 @@ static void emu_guest_push_audio(void *userdata, const int16_t *data,
 static void emu_host_mousemove(void *userdata, int port, int x, int y) {
   struct emu *emu = userdata;
 
+#ifdef HAVE_IMGUI
   imgui_mousemove(emu->imgui, x, y);
+#endif
+#ifdef HAVE_MICROPROFILE
   mp_mousemove(emu->mp, x, y);
+#endif
 }
 
 static void emu_host_keydown(void *userdata, int port, enum keycode key,
@@ -426,8 +434,12 @@ static void emu_host_keydown(void *userdata, int port, enum keycode key,
   if (key == K_F1 && value > 0) {
     emu->debug_menu = emu->debug_menu ? 0 : 1;
   } else {
+#ifdef HAVE_IMGUI
     imgui_keydown(emu->imgui, key, value);
+#endif
+#ifdef HAVE_MICROPROFILE
     mp_keydown(emu->mp, key, value);
+#endif
   }
 
   if (key >= K_CONT_C && key <= K_CONT_RTRIG) {
@@ -444,15 +456,19 @@ static void emu_host_context_destroyed(void *userdata) {
     emu_free_texture(emu, tex);
   }
 
+#ifdef HAVE_MICROPROFILE
   if (emu->mp) {
     mp_destroy(emu->mp);
     emu->mp = NULL;
   }
+#endif
 
+#ifdef HAVE_IMGUI
   if (emu->imgui) {
     imgui_destroy(emu->imgui);
     emu->imgui = NULL;
   }
+#endif
 
   if (emu->r) {
     r_destroy(emu->r);
@@ -466,8 +482,12 @@ static void emu_host_context_reset(void *userdata) {
   emu_host_context_destroyed(userdata);
 
   emu->r = video_create_renderer(emu->host);
+#ifdef HAVE_IMGUI
   emu->imgui = imgui_create(emu->r);
+#endif
+#ifdef HAVE_MICROPROFILE
   emu->mp = mp_create(emu->r);
+#endif
 }
 
 static void emu_host_resized(void *userdata) {
@@ -665,8 +685,12 @@ void emu_render_frame(struct emu *emu) {
   int debug_x = 0;
   int debug_y = 0;
 
+#ifdef HAVE_MICROPROFILE
   mp_begin_frame(emu->mp, debug_width, debug_height);
+#endif
+#ifdef HAVE_IMGUI
   imgui_begin_frame(emu->imgui, debug_width, debug_height);
+#endif
 
   r_clear(emu->r);
 
@@ -724,8 +748,12 @@ void emu_render_frame(struct emu *emu) {
     prof_flip(now);
 
     r_viewport(emu->r, debug_x, debug_y, debug_width, debug_height);
+#ifdef HAVE_IMGUI
     imgui_render(emu->imgui);
+#endif
+#ifdef HAVE_MICROPROFILE
     mp_render(emu->mp);
+#endif
 
     if (emu->last_paint) {
       float frame_time_ms = (float)(now - emu->last_paint) / 1000000.0f;

--- a/src/guest/debugger.c
+++ b/src/guest/debugger.c
@@ -1,11 +1,14 @@
+#ifdef HAVE_DEBUGGER
 #include "gdb/gdb_server.h"
 #define GDB_SERVER_IMPL
 #include "gdb/gdb_server.h"
+#endif
 
 #include "core/log.h"
 #include "guest/debugger.h"
 #include "guest/dreamcast.h"
 
+#ifdef HAVE_DEBUGGER
 struct debugger {
   struct dreamcast *dc;
   struct device *dev;
@@ -55,8 +58,10 @@ static void debugger_gdb_server_read_reg(void *data, int n, intmax_t *value,
   dbg->dev->debug_if->read_reg(dbg->dev, n, &v, size);
   *value = v;
 }
+#endif
 
 int debugger_init(struct debugger *dbg) {
+#ifdef HAVE_DEBUGGER
   /* use the first device found with a debug interface */
   list_for_each_entry(dev, &dbg->dc->devices, struct device, it) {
     if (dev->debug_if) {
@@ -85,33 +90,44 @@ int debugger_init(struct debugger *dbg) {
   target.read_mem = &debugger_gdb_server_read_mem;
 
   dbg->sv = gdb_server_create(&target, 24690);
-  if (!dbg->sv) {
-    LOG_WARNING("Failed to create GDB server");
-    return 0;
+  if (dbg->sv) {
+    return 1;
   }
 
-  return 1;
+  LOG_WARNING("Failed to create GDB server");
+#endif
+  return 0;
 }
 
 void debugger_trap(struct debugger *dbg) {
+#ifdef HAVE_DEBUGGER
   gdb_server_interrupt(dbg->sv, GDB_SIGNAL_TRAP);
 
   dc_suspend(dbg->dc);
+#endif
 }
 
 void debugger_tick(struct debugger *dbg) {
+#ifdef HAVE_DEBUGGER
   gdb_server_pump(dbg->sv);
+#endif
 }
 
 struct debugger *debugger_create(struct dreamcast *dc) {
+#ifdef HAVE_DEBUGGER
   struct debugger *dbg = calloc(1, sizeof(struct debugger));
 
   dbg->dc = dc;
 
   return dbg;
+#else
+  return NULL;
+#endif
 }
 
 void debugger_destroy(struct debugger *dbg) {
+#ifdef HAVE_DEBUGGER
   gdb_server_destroy(dbg->sv);
   free(dbg);
+#endif
 }


### PR DESCRIPTION
@inolen This should make the shallow fork hosted at libretro organization completely unnecessary so that we can remove it. I will offer to maintain this static Makefile too in case you feel it's a maintenance burden.

Note: I had to add some defines like HAVE_IMGUI/HAVE_DEBUGGER. You will have to define these for your non-libretro standalone builds in case you want to use the imgui interface and/or the debugger. It might be possible to use these with the libretro port too, but the static Makefile target has them baked out for now.

Hopefully I did not introduce any mistakes.