### PR TITLE
More persistent options and fullscreen support (SDL)

### DIFF
--- a/src/emulator.c
+++ b/src/emulator.c
@@ -38,6 +38,7 @@
 DEFINE_AGGREGATE_COUNTER(frames);
 
 DEFINE_PERSISTENT_OPTION_STRING(aspect_ratio, "stretch", "Video aspect ratio");
+DEFINE_PERSISTENT_OPTION_INT(dbg_menu, 1, "Debug Menu Show");
 
 enum {
   ASPECT_RATIO_STRETCH,
@@ -431,6 +432,10 @@ static void emu_host_keydown(void *userdata, int port, enum keycode key,
 
   if (key == K_F1 && value > 0) {
     emu->debug_menu = emu->debug_menu ? 0 : 1;
+    /* Update the Persistent Flag */
+    OPTION_dbg_menu = emu->debug_menu;
+  } else if (key == K_F12 && value > 0) {
+    host_toggle_fullscreen();
   } else {
     imgui_keydown(emu->imgui, key, value);
     mp_keydown(emu->mp, key, value);
@@ -837,7 +842,7 @@ struct emu *emu_create(struct host *host) {
   }
 
   /* enable debug menu by default */
-  emu->debug_menu = 1;
+  emu->debug_menu = OPTION_dbg_menu;
 
   /* enable the cpu / gpu to be emulated in parallel */
   emu->multi_threaded = 1;

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -435,7 +435,7 @@ static void emu_host_keydown(void *userdata, int port, enum keycode key,
     /* Update the Persistent Flag */
     OPTION_dbg_menu = emu->debug_menu;
   } else if (key == K_F12 && value > 0) {
-    host_toggle_fullscreen();
+    video_toggle_fullscreen();
   } else {
     imgui_keydown(emu->imgui, key, value);
     mp_keydown(emu->mp, key, value);

--- a/src/host/host.h
+++ b/src/host/host.h
@@ -25,6 +25,7 @@ void audio_push(struct host *host, const int16_t *data, int frames);
 /* video */
 int video_width(struct host *host);
 int video_height(struct host *host);
+void host_toggle_fullscreen(void);
 
 struct render_backend *video_create_renderer(struct host *host);
 void video_destroy_renderer(struct host *host, struct render_backend *r);

--- a/src/host/host.h
+++ b/src/host/host.h
@@ -25,7 +25,7 @@ void audio_push(struct host *host, const int16_t *data, int frames);
 /* video */
 int video_width(struct host *host);
 int video_height(struct host *host);
-void host_toggle_fullscreen(void);
+void video_toggle_fullscreen(void);
 
 struct render_backend *video_create_renderer(struct host *host);
 void video_destroy_renderer(struct host *host, struct render_backend *r);

--- a/src/host/null_host.c
+++ b/src/host/null_host.c
@@ -36,6 +36,10 @@ int video_width(struct host *base) {
   return 0;
 }
 
+void video_toggle_fullscreen(void){
+  return;
+}
+
 /*
  * input
  */

--- a/src/host/retro_host.c
+++ b/src/host/retro_host.c
@@ -40,7 +40,6 @@ static retro_input_state_t input_state_cb;
   { port, RETRO_DEVICE_JOYPAD, 0,                              RETRO_DEVICE_ID_JOYPAD_Y,     "X" },           \
   { port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X,     "Analog X" },    \
   { port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y,     "Analog Y" },    \
-  { port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y,     "Analog Y" },    \
   { port, RETRO_DEVICE_JOYPAD, 0,                              RETRO_DEVICE_ID_JOYPAD_L2,    "L" },           \
   { port, RETRO_DEVICE_JOYPAD, 0,                              RETRO_DEVICE_ID_JOYPAD_R2,    "R" }
 

--- a/src/host/retro_host.c
+++ b/src/host/retro_host.c
@@ -40,6 +40,7 @@ static retro_input_state_t input_state_cb;
   { port, RETRO_DEVICE_JOYPAD, 0,                              RETRO_DEVICE_ID_JOYPAD_Y,     "X" },           \
   { port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X,     "Analog X" },    \
   { port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y,     "Analog Y" },    \
+  { port, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y,     "Analog Y" },    \
   { port, RETRO_DEVICE_JOYPAD, 0,                              RETRO_DEVICE_ID_JOYPAD_L2,    "L" },           \
   { port, RETRO_DEVICE_JOYPAD, 0,                              RETRO_DEVICE_ID_JOYPAD_R2,    "R" }
 
@@ -107,6 +108,10 @@ int video_height(struct host *base) {
 
 int video_width(struct host *base) {
   return VIDEO_WIDTH;
+}
+
+void host_toggle_fullscreen(void){
+  return;
 }
 
 /*

--- a/src/host/retro_host.c
+++ b/src/host/retro_host.c
@@ -109,7 +109,7 @@ int video_width(struct host *base) {
   return VIDEO_WIDTH;
 }
 
-void host_toggle_fullscreen(void){
+void video_toggle_fullscreen(void){
   return;
 }
 

--- a/src/host/sdl_host.c
+++ b/src/host/sdl_host.c
@@ -754,15 +754,23 @@ void host_destroy(struct sdl_host *host) {
 
 struct sdl_host *host_create() {
   struct sdl_host *host = calloc(1, sizeof(struct sdl_host));
+  int mode;
 
   /* init sdl and create window */
   int res = SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER);
   CHECK_GE(res, 0, "host_create sdl initialization failed: %s", SDL_GetError());
 
+  /* Test for fullscreen flag and set mode accordingly */
+  if( OPTION_fullscreen ) {
+    mode = SDL_WINDOW_FULLSCREEN_DESKTOP;
+  }else{
+    mode = SDL_WINDOW_RESIZABLE;
+  }
+
   host->win = SDL_CreateWindow("redream", SDL_WINDOWPOS_UNDEFINED,
                                SDL_WINDOWPOS_UNDEFINED, OPTION_v_width,
                                OPTION_v_height,
-                               SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+                               SDL_WINDOW_OPENGL | mode);
   CHECK_NOTNULL(host->win, "host_create window creation failed: %s",
                 SDL_GetError());
 
@@ -817,11 +825,6 @@ int main(int argc, char **argv) {
   g_host = host_create();
   if (!g_host) {
     return EXIT_FAILURE;
-  }
-
-  /* Test for fullscreen flag and update accordingly */
-  if( OPTION_fullscreen ) {
-       SDL_SetWindowFullscreen(g_host->win, SDL_WINDOW_FULLSCREEN_DESKTOP);
   }
 
   const char *load = argc > 1 ? argv[1] : NULL;

--- a/src/host/sdl_host.c
+++ b/src/host/sdl_host.c
@@ -295,6 +295,18 @@ static int video_init(struct sdl_host *host) {
   return 1;
 }
 
+void video_toggle_fullscreen(void){
+  int IsFullscreen = SDL_GetWindowFlags(g_host->win) & SDL_WINDOW_FULLSCREEN_DESKTOP;
+  int status = SDL_SetWindowFullscreen(g_host->win, IsFullscreen ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP);
+
+  /* Check that SDL_SetWindowFullscreen returned success */
+  if(status == 0){
+    /* Update the persistent option
+       NOTE: The new mode is the inverse of the original feedback */
+    OPTION_fullscreen = !IsFullscreen;
+  }
+}
+
 /*
  * input
  */
@@ -774,18 +786,6 @@ struct sdl_host *host_create() {
   }
 
   return host;
-}
-
-void host_toggle_fullscreen(void){
-  int IsFullscreen = SDL_GetWindowFlags(g_host->win) & SDL_WINDOW_FULLSCREEN_DESKTOP;
-  int status = SDL_SetWindowFullscreen(g_host->win, IsFullscreen ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP);
-
-  /* Check that SDL_SetWindowFullscreen returned success */
-  if(status == 0){
-    /* Update the persistent option
-       NOTE: The new mode is the inverse of the original feedback */
-    OPTION_fullscreen = !IsFullscreen;
-  }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
I could not find any method of enabling or toggling fullscreen support so I added it to this commit. (If fullscreen support already exists somewhere then some of this pull request can be ignored)

This commit adds some additional persistent options:

Video Width, Video Height, Fullscreen, dbg_menu
It also adds the ability to toggle fullscreen mode by pressing F12.

This will give the opportunity for launchers/frontends to control some of the key functions via the command line.