### PR TITLE
Fix Makefile paths and missing cimgui.h include.

### DIFF
--- a/deps/libretro/Makefile
+++ b/deps/libretro/Makefile
@@ -19,8 +19,8 @@ CAPSTONE_HAS_ARM64=0
 UNAME=$(shell uname -a)
 
 # Dirs
-ROOT_DIR := .
-CORE_DIR := .
+ROOT_DIR := ../..
+CORE_DIR := ../..
 LIBRETRO_DIR := $(ROOT_DIR)/deps/libretro
 
 ifeq ($(platform),)


### PR DESCRIPTION
This is the second attempt at this. Now that I have been looking at the libretro buildbot script and associated recipes I noticed the redream recipes are wrong to accommodate for this issue.

What this fixes is:
```
make -C deps/libretro
cd deps/libretro; make
```
What will no longer work which should be the expected behavior.
```
make -f deps/libretro/Makefile
```
Additionally this change managed to introduce the missing `cimgui.h` include from the buildbot logs which I fixed with `HAVE_IMGUI=1`. Is this a correct fix? Hopefully it will fix it for other platforms too.

From the buildbot logs.
```
In file included from src/guest/gdrom/gdrom.c:7:0:
./src/imgui.h:6:27: fatal error: cimgui/cimgui.h: No such file or directory
compilation terminated.
deps/libretro/Makefile:476: recipe for target 'src/guest/gdrom/gdrom.o' failed
make: *** [src/guest/gdrom/gdrom.o] Error 1
make: *** Waiting for unfinished jobs....
```